### PR TITLE
Fixed KitodoAccessViewHelper, fixed private user edit / administration edit

### DIFF
--- a/Classes/ViewHelpers/KitodoAccessViewHelper.php
+++ b/Classes/ViewHelpers/KitodoAccessViewHelper.php
@@ -25,6 +25,8 @@ namespace Slub\DigasFeManagement\ViewHelpers;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3\CMS\Core\Context\Context;
@@ -68,6 +70,19 @@ class KitodoAccessViewHelper extends AbstractViewHelper
      */
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
+        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
+        $configurationManager = $objectManager->get('TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface');
+        $typoscriptConfiguration = $configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
+
+        //check general access
+        if (!empty($settings = $typoscriptConfiguration['plugin.']['tx_digasfemanagement.']['settings.'])) {
+            $kitodoGroupsAccess = array_intersect(explode(',', $GLOBALS['TSFE']->fe_user->user['usergroup']), explode(',', $typoscriptConfiguration['plugin.']['tx_digasfemanagement.']['settings.']['kitodoAccessGroups']));
+        }
+
+        if(!empty($kitodoGroupsAccess)) {
+            return true;
+        }
+
         if(GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect('frontend.user','isLoggedIn')) {
             $accessIds = explode("\r\n", $GLOBALS['TSFE']->fe_user->user['kitodo_feuser_access']);
             return in_array($arguments['id'], $accessIds);

--- a/Configuration/TypoScript/Setup/Extensions/config/setup.typoscript
+++ b/Configuration/TypoScript/Setup/Extensions/config/setup.typoscript
@@ -27,6 +27,8 @@ plugin.tx_digasfemanagement {
         search {
             dateFormat = %d.%m.%y - %H:%M
         }
+
+        kitodoAccessGroups = {$femanager.kitodoAccessGroups}
     }
 }
 

--- a/Configuration/TypoScript/Setup/Extensions/femanager/00-config.typoscript
+++ b/Configuration/TypoScript/Setup/Extensions/femanager/00-config.typoscript
@@ -62,6 +62,7 @@ plugin.tx_femanager {
             pids {
                 createInstitutional = {$femanager.administration.pids.createInstitutional}
                 createPrivate = {$femanager.administration.pids.createPrivate}
+                editUserUid = {$femanager.administration.pids.editUserUid}
             }
         }
 

--- a/Configuration/TypoScript/Setup/Extensions/femanager/30-setup-administration.typoscript
+++ b/Configuration/TypoScript/Setup/Extensions/femanager/30-setup-administration.typoscript
@@ -1,7 +1,5 @@
 plugin.tx_femanager {
     settings {
-        showCompanyFields = 1
-
         administration {
             validation {
                 _enable.client = 0
@@ -32,3 +30,11 @@ plugin.tx_femanager {
         }
     }
 }
+
+[page["uid"] == {$femanager.administration.pids.editUserUid}]
+    plugin.tx_femanager {
+        settings {
+            showCompanyFields = 1
+        }
+    }
+[end]

--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -39,6 +39,9 @@ femanager {
     # cat=plugin.tx_digasfemanagement/; type=int; label=Uid for frontend users
     feUserGroup =
 
+    # cat=plugin.tx_digasfemanagement/; type=int; label=Group access for documents (comma separated group uids)
+    kitodoAccessGroups =
+
     administration {
         pids {
 

--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -50,6 +50,9 @@ femanager {
 
             # cat=plugin.tx_digasfemanagement/; type=int+; label=Page uid of admin create private user plugin
             createPrivate =
+
+            # cat=plugin.tx_digasfemanagement/; type=int+; label=Page uid of admin list,edit,view plugin
+            editUserUid =
         }
 
         #  cat=plugin.tx_digasfemanagement/; type=string; label=Listing View - Administration user search fields (possible values are address, city, company, country, email, fax, first_name, image, last_name, middle_name, name, telephone, title, usergroup.title, username, www, zip)


### PR DESCRIPTION
Changelist:

- KitodoAccessViewHelper:
  - add new typoscript constant: _femanager.kitodoAccessGroups_
  - grant access to Kitodo documents if current user is in _femanager.kitodoAccessGroups_ group

- fixed error on edit private user profile / create new private user as administrator
  - add new typoscript constant: _femanager.administration.pids.editUserUid_ (must be page uid of administration list/edit)
