### PR TITLE
KitodoAccessViewhelper & StatisticController

### DIFF
--- a/Classes/Controller/StatisticController.php
+++ b/Classes/Controller/StatisticController.php
@@ -67,18 +67,6 @@ class StatisticController extends AbstractController
             return $this->redirectToUri($uri);
         }
 
-        //test, if access is granted
-        $arguments = GeneralUtility::_GP('tx_dlf');
-        $accessIds = explode("\r\n", $this->user->getKitodoFeuserAccess());
-        if(!in_array($arguments['id'], $accessIds)) {
-            $uriBuilder = $this->uriBuilder;
-            $uri = $uriBuilder
-                    ->setTargetPageUid($this->settings['pids']['contactFormUid'])
-                    ->setArguments(['gp-id' => $arguments['id']])
-                    ->build();
-            return $this->redirectToUri($uri);
-        }
-
         $statisticEntry = new Statistic();
 
         $statisticEntry->setFeUser($this->user);


### PR DESCRIPTION
- Remove access check from StatisticController
- fix KitodoAccessViewhelper: add check for general access (returns TRUE, if "tx_dlf_documents.restrictions" === "ja" -- see line 99 -- I'm not quite sure if this needs to be vice versa?!?)
- fix KitodoAccessViewhelper: change check for personal access, now checking if "tx_dlf_documents.record_id" equals any value in "fe_user.kitodo_feuser_access"