### PR TITLE
[BUGFIX] Initialize `$timeSpan` variable as `0` instead `null`

### DIFF
--- a/Classes/Command/DeleteDeactivatedAccountsCommand.php
+++ b/Classes/Command/DeleteDeactivatedAccountsCommand.php
@@ -73,17 +73,17 @@ class DeleteDeactivatedAccountsCommand extends DigasBaseCommand
         // Initialize IO
         parent::execute($input, $output);
 
-        $timespan = null;
+        $timeSpan = 0;
         if (MathUtility::canBeInterpretedAsInteger($input->getArgument('timespan'))) {
-            $timespan = MathUtility::forceIntegerInRange((int)$input->getArgument('timespan'), 0);
+            $timeSpan = MathUtility::forceIntegerInRange((int)$input->getArgument('timespan'), 0);
         }
         $deleteCounter = 0;
-        if ($timespan <= 0) {
+        if ($timeSpan <= 0) {
             $this->io->error('"timespan" has to a positive integer value. Abort.');
             return 1;
         }
         $time = new \DateTime();
-        $deleteTimestamp = $time->getTimestamp() - ((60 * 60 * 24) * $timespan);
+        $deleteTimestamp = $time->getTimestamp() - ((60 * 60 * 24) * $timeSpan);
 
         $feUsers = $this->UserRepository->findDeactivatedAccounts($deleteTimestamp, $this->feUserGroups);
 

--- a/Classes/Command/DeleteInactiveAccountsCommand.php
+++ b/Classes/Command/DeleteInactiveAccountsCommand.php
@@ -73,17 +73,17 @@ class DeleteInactiveAccountsCommand extends DigasBaseCommand
         parent::execute($input, $output);
 
         $deleteCounter = 0;
-        $timespan = null;
+        $timeSpan = 0;
         if (MathUtility::canBeInterpretedAsInteger($input->getArgument('timespan'))) {
-            $timespan = MathUtility::forceIntegerInRange((int)$input->getArgument('timespan'), 0);
+            $timeSpan = MathUtility::forceIntegerInRange((int)$input->getArgument('timespan'), 0);
         }
-        if ($timespan <= 0) {
+        if ($timeSpan <= 0) {
             $this->io->error('"timespan" has to a positive integer value. Abort.');
             return 1;
         }
-        $deleteTimespan = time() - (60 * 60 * (int)$timespan);
+        $deleteTimeSpan = time() - (60 * 60 * (int)$timeSpan);
 
-        $feUsers = $this->UserRepository->findInactiveAccounts($deleteTimespan, $this->feUserGroups);
+        $feUsers = $this->UserRepository->findInactiveAccounts($deleteTimeSpan, $this->feUserGroups);
 
         if (!empty($feUsers)) {
             $deleteCounter = $this->deleteFeUsers($feUsers);

--- a/Classes/Command/DeleteTemporaryUsersCommand.php
+++ b/Classes/Command/DeleteTemporaryUsersCommand.php
@@ -74,17 +74,17 @@ class DeleteTemporaryUsersCommand extends DigasBaseCommand
         parent::execute($input, $output);
 
         $deleteCounter = 0;
-        $timespan = null;
+        $timeSpan = 0;
         if (MathUtility::canBeInterpretedAsInteger($input->getArgument('timespan'))) {
-            $timespan = MathUtility::forceIntegerInRange((int)$input->getArgument('timespan'), 0);
+            $timeSpan = MathUtility::forceIntegerInRange((int)$input->getArgument('timespan'), 0);
         }
-        if ($timespan <= 0) {
+        if ($timeSpan <= 0) {
             $this->io->error('"timespan" has to a positive integer value. Abort.');
             return 1;
         }
 
         $time = new \DateTime();
-        $deleteTimestamp = $time->getTimestamp() - ((60 * 60 * 24) * $timespan);
+        $deleteTimestamp = $time->getTimestamp() - ((60 * 60 * 24) * $timeSpan);
 
         // set storage pid for temporary fe_users
         $this->UserRepository->setStoragePid($this->settings['pids.']['kitodoTempUserPid']);


### PR DESCRIPTION
Variable `$timeSpan` initialized as `null` cant be used in comparison in `if` condition without `null` check.

There were two solutions here, add `null` check or initialize variable as `0`.