### PR TITLE
[BUGFIX] Remove not needed paramater `$isOnline`

### DIFF
--- a/Classes/Domain/Model/User.php
+++ b/Classes/Domain/Model/User.php
@@ -78,15 +78,6 @@ class User extends \In2code\Femanager\Domain\Model\User
     protected $hidden;
 
     /**
-     * Sets the inactivemessageTstamp
-     *
-     * @param \DateTime $inactivemessageTstamp
-     * @return void
-     * @var int
-     */
-    protected $isOnline = false;
-
-    /**
      * oldAccount
      *
      * @var int


### PR DESCRIPTION
Class `\In2code\Femanager\Domain\Model\User` contains it already