### PR TITLE
[BUGFIX] Fix error message overwriting

### DIFF
--- a/Classes/Hooks/FeUserHook.php
+++ b/Classes/Hooks/FeUserHook.php
@@ -104,11 +104,9 @@ class FeUserHook {
                     //login existing user with new username / email
                     $this->loginUser($userToChange);
                 } catch (UnknownObjectException $e) {
-                    new UnknownObjectException('User could not be updated. UnknownObjectException');
-                    return;
+                    throw new UnknownObjectException('User could not be updated. ' . $e->getMessage());
                 } catch (IllegalObjectTypeException $e) {
-                    new Exception('User could not be updated. IllegalObjectTypeException');
-                    return;
+                    throw new IllegalObjectTypeException('User could not be updated. ' . $e->getMessage());
                 }
             }
         }

--- a/Classes/Slots/AfterPasswordChange.php
+++ b/Classes/Slots/AfterPasswordChange.php
@@ -118,13 +118,10 @@ class AfterPasswordChange
             try {
                 //update user
                 $this->userRepository->update($userToUpdate);
-
             } catch (UnknownObjectException $e) {
-                new UnknownObjectException('User could not be updated. UnknownObjectException');
-                return;
+                throw new UnknownObjectException('User could not be updated. ' . $e->getMessage());
             } catch (IllegalObjectTypeException $e) {
-                new Exception('User could not be updated. IllegalObjectTypeException');
-                return;
+                throw new IllegalObjectTypeException('User could not be updated. ' . $e->getMessage());
             }
         }
     }


### PR DESCRIPTION
Problem: `Call to Exception::__construct() on a separate line has no effect.`