### PR TITLE
[BUGFIX] Add `kitodo-presentation` repository to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
     "require": {
         "typo3/cms-core": "^10.4|^11.5",
         "in2code/femanager": "^7.2",
-        "derhansen/fe_change_pwd": "^3.1"
+        "derhansen/fe_change_pwd": "^3.1",
+        "kitodo/presentation": "^5.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.11",


### PR DESCRIPTION
It is needed for `Kitodo\Dlf\Domain\Model\Document` class. This class is used inside thia repository and marked as missing by `PHPStan` checks.