### PR TITLE
[BUGFIX] Remove `empty()` check for `$user`

### DIFF
--- a/Classes/Command/DigasBaseCommand.php
+++ b/Classes/Command/DigasBaseCommand.php
@@ -205,7 +205,7 @@ class DigasBaseCommand extends Command
     protected function notifyUser(User $feUser, array $userDocumentEntries)
     {
         // get fe_user data
-        if (!empty($feUser) && !empty($userDocumentEntries)) {
+        if (!empty($userDocumentEntries)) {
             $documentsList = [];
             foreach ($userDocumentEntries as $accessEntry) {
                 $documentsList[] = [

--- a/Classes/Controller/AdministrationController.php
+++ b/Classes/Controller/AdministrationController.php
@@ -83,7 +83,7 @@ class AdministrationController extends AbstractController
      */
     public function showAction(User $user)
     {
-        if (!empty($user) && !empty($user->getUid())) {
+        if (!empty($user->getUid())) {
             $this->view->assign('user', $this->userRepository->findByUid($user->getUid()));
             $this->assignForAll();
         }
@@ -96,7 +96,7 @@ class AdministrationController extends AbstractController
      */
     public function editUserAction(User $user)
     {
-        if (!empty($user) && !empty($user->getUid())) {
+        if (!empty($user->getUid())) {
             $token = GeneralUtility::hmac((string)$user->getUid(), (string)$user->getCrdate()->getTimestamp());
 
             /** @var UserGroup[] $feUserGroup */
@@ -144,7 +144,7 @@ class AdministrationController extends AbstractController
      */
     public function deactivateUserAction(User $user, $setActiveState = false)
     {
-        if (!empty($user)) {
+        if (!empty($user->getUid())) {
             $this->signalSlotDispatcher->dispatch(__CLASS__, __FUNCTION__, [$user, $this]);
             $logUtility = GeneralUtility::makeInstance(LogUtility::class);
             $logUtility->log(Log::STATUS_ADMINISTRATION_PROFILE_DEACTIVATE, $user);

--- a/Classes/Controller/BasketController.php
+++ b/Classes/Controller/BasketController.php
@@ -263,7 +263,7 @@ class BasketController extends AbstractController
      */
     protected function checkUserLoggedIn()
     {
-        if (empty($this->user) || empty($this->user->getUid())) {
+        if (empty($this->user->getUid())) {
             $uriBuilder = $this->uriBuilder;
             $uri = $uriBuilder->setTargetPageUid($this->settings['pids']['loginPage'])->build();
             $this->redirectToUri($uri);

--- a/Classes/Controller/StatisticController.php
+++ b/Classes/Controller/StatisticController.php
@@ -109,7 +109,7 @@ class StatisticController extends AbstractController
     public function downloadLinkAction(string $id, string $countType)
     {
         // make sure, the user is logged in
-        if (empty($this->user) || empty($this->user->getUid())) {
+        if (empty($this->user->getUid())) {
             $this->view->assign('counted', -1);
             return;
         }


### PR DESCRIPTION
 Property `In2code\Femanager\Controller\AbstractController::$user` is never empty.