### PR TITLE
[BUGFIX] Fix type for `sendRequestAccessMail()` function

### DIFF
--- a/.github/phpstan.neon
+++ b/.github/phpstan.neon
@@ -13,7 +13,6 @@ parameters:
     - '#Parameter \$kitodoDocumentRepository of method Slub\\DigasFeManagement\\Controller\\StatisticController::injectKitodoDocumentRepository\(\) has invalid type Slub\\SlubWebDigas\\Domain\\Repository\\KitodoDocumentRepository\.#'
     - '#Parameter \$dlfDocument of method Slub\\DigasFeManagement\\Domain\\Model\\Access::setDlfDocument\(\) has invalid type Slub\\SlubWebDigas\\Domain\\Model\\KitodoDocument\.#'
     - '#Parameter \$document of method Slub\\DigasFeManagement\\Domain\\Model\\Statistic::setDocument\(\) has invalid type Slub\\SlubWebDigas\\Domain\\Model\\KitodoDocument\.#'
-    - '#Parameter \$documents of method Slub\\DigasFeManagement\\Controller\\BasketController::sendRequestAccessMail\(\) has invalid type Slub\\SlubWebDigas\\Domain\\Model\\KitodoDocument\.#'
     - '#Property Slub\\DigasFeManagement\\Controller\\StatisticController::\$kitodoDocumentRepository has unknown class Slub\\SlubWebDigas\\Domain\\Repository\\KitodoDocumentRepository as its type\.#'
     - '#Property Slub\\DigasFeManagement\\Domain\\Model\\Access::\$dlfDocument has unknown class Slub\\SlubWebDigas\\Domain\\Model\\KitodoDocument as its type\.#'
     - '#Property Slub\\DigasFeManagement\\Domain\\Model\\Statistic::\$document has unknown class Slub\\SlubWebDigas\\Domain\\Model\\KitodoDocument as its type\.#'

--- a/Classes/Controller/BasketController.php
+++ b/Classes/Controller/BasketController.php
@@ -28,11 +28,9 @@ namespace Slub\DigasFeManagement\Controller;
 use In2code\Femanager\Controller\AbstractController;
 use In2code\Femanager\Utility\StringUtility;
 use Slub\DigasFeManagement\Domain\Model\Access;
-use Slub\SlubWebDigas\Domain\Model\KitodoDocument;
 use TYPO3\CMS\Extbase\Mvc\Exception\StopActionException;
 use TYPO3\CMS\Extbase\Persistence\Exception\IllegalObjectTypeException;
 use TYPO3\CMS\Extbase\Persistence\Exception\UnknownObjectException;
-use TYPO3\CMS\Extbase\Persistence\Generic\QueryResult;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 /**
@@ -275,7 +273,7 @@ class BasketController extends AbstractController
     /**
      * Send request access mail with kitodo documents and reset basket cookie
      *
-     * @param KitodoDocument[] $documents
+     * @param Access[] $documents
      * @param string $message
      * @return bool
      */


### PR DESCRIPTION
It takes array of `Access` elements, which contain `KitodoDocument` elements:

```
$requestAccess = new Access();
$requestAccess->setFeUser($this->user->getUid());
$requestAccess->setRecordId($document->getRecordId());
$requestAccess->setHidden(true);
$requestAccess->setDlfDocument($document);
```

Actually` setDlfDocument()` function takes as parameter `KitodoDocument` object.