### PR TITLE
Bugfix adminstatsitic

### DIFF
--- a/Classes/Controller/StatisticController.php
+++ b/Classes/Controller/StatisticController.php
@@ -179,6 +179,7 @@ class StatisticController extends AbstractController
 
         $this->view->assignMultiple([
             'statistic' => $statistic['result'],
+            'totals' => $statistic['totals'],
             'dateFrom' => $statistic['dateFrom'],
             'dateTo' => $statistic['dateTo']
         ]);
@@ -204,6 +205,7 @@ class StatisticController extends AbstractController
         $this->view->assignMultiple([
             'userId' => $userId,
             'statistic' => $statistic['result'],
+            'totals' => $statistic['totals'],
             'dateFrom' => $statistic['dateFrom'],
             'dateTo' => $statistic['dateTo']
         ]);
@@ -220,9 +222,28 @@ class StatisticController extends AbstractController
 
         $this->view->assignMultiple([
             'statistic' => $statistic['result'],
+            'totals' => $statistic['totals'],
             'dateFrom' => $statistic['dateFrom'],
             'dateTo' => $statistic['dateTo']
         ]);
+    }
+
+    /**
+     * Compute totals across all statistic entries.
+     *
+     * @param array $result
+     *
+     * @return array
+     */
+    private function computeTotals(array $result): array
+    {
+        $totals = ['downloadPages' => 0, 'downloadWork' => 0, 'workViews' => 0];
+        foreach ($result as $entry) {
+            $totals['downloadPages'] += $entry->getDownloadPages();
+            $totals['downloadWork']  += $entry->getDownloadWork();
+            $totals['workViews']     += $entry->getWorkViews();
+        }
+        return $totals;
     }
 
     /**
@@ -283,16 +304,21 @@ class StatisticController extends AbstractController
         if ($requestMethod === 'POST' && $filterSubmit === true) {
             $filterParams = $this->request->getArgument('statistic');
             $statisticFilter = $this->validateStatisticFilter($filterParams);
+            $result = $this->statisticRepository->findForFilter($statisticFilter['dateFrom'], $statisticFilter['dateTo'], $userId);
 
             return [
-                'result' => $this->statisticRepository->findForFilter($statisticFilter['dateFrom'], $statisticFilter['dateTo'], $userId),
+                'result' => $result,
+                'totals' => $this->computeTotals($result),
                 'dateFrom' => $statisticFilter['dateFrom'],
                 'dateTo' => $statisticFilter['dateTo']
             ];
 
         } else {
+            $result = $this->statisticRepository->findForStatistic($userId);
+
             return [
-                'result' => $this->statisticRepository->findForStatistic($userId),
+                'result' => $result,
+                'totals' => $this->computeTotals($result),
                 'dateFrom' => null,
                 'dateTo' => date('Y-m-d')
             ];

--- a/Classes/Domain/Repository/StatisticRepository.php
+++ b/Classes/Domain/Repository/StatisticRepository.php
@@ -125,7 +125,7 @@ class StatisticRepository extends Repository
     {
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($this->tableName)->createQueryBuilder();
         $queryBuilder->select('*')
-            ->addSelectLiteral($queryBuilder->expr()->count('uid', 'download_work'))
+            ->addSelectLiteral($queryBuilder->expr()->sum('download_work', 'download_work'))
             ->addSelectLiteral($queryBuilder->expr()->sum('download_pages', 'download_pages'))
             ->addSelectLiteral($queryBuilder->expr()->sum('work_views', 'work_views'))
             ->from($this->tableName)

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -445,6 +445,9 @@ Please login in the next %s days to avoid the account deletion.]]></source>
 			<trans-unit id="statistic.table.workViews">
 				<source><![CDATA[Views in Workview]]></source>
 			</trans-unit>
+			<trans-unit id="statistic.table.total">
+				<source><![CDATA[Gesamt]]></source>
+			</trans-unit>
 			<trans-unit id="submitChangeEmail">
 				<source><![CDATA[Change e-mail-address]]></source>
 			</trans-unit>

--- a/Resources/Private/Partials/Statistic/Result.html
+++ b/Resources/Private/Partials/Statistic/Result.html
@@ -17,6 +17,12 @@
             <td>{statisticEntry.workViews}</td>
         </tr>
     </f:for>
+    <tr class="fe-management-statistic-total">
+        <td><strong><f:translate key="statistic.table.total"/></strong></td>
+        <td><strong>{totals.downloadPages}</strong></td>
+        <td><strong>{totals.downloadWork}</strong></td>
+        <td><strong>{totals.workViews}</strong></td>
+    </tr>
     </tbody>
 </table>
 </html>


### PR DESCRIPTION
Statistic was always showing +1 in each category (view, download) even if no download happened. 
Fixed that bug and also added a new line with total result depending on set time.

<img width="864" height="72" alt="image" src="https://github.com/user-attachments/assets/74dd4a19-036d-4744-ac3f-774028e94e13" />


